### PR TITLE
[REVERT:WORKAROUND:build] Strict builds prevent imaged from displayin…

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -25,4 +25,4 @@ jobs:
           pip install --requirement requirements.txt
           properdocs --version
       - name: build ULHPC documentation
-        run: properdocs build && properdocs gh-deploy --force
+        run: properdocs build --strict && properdocs gh-deploy --force


### PR DESCRIPTION
…g properly

This reverts commit 485264271d7b11841bad608947e5dcb14e6167f2. The strict option is not affecting the display of images.