### PR TITLE
Revert "[BUGFIX] Use correct deployment branch name"

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -45,7 +45,7 @@ jobs:
     needs: build
     runs-on: ubuntu-latest
     environment:
-      name: gh-deploy
+      name: github-pages
       url: ${{ steps.deployment.outputs.page_url }}
     steps:
       - name: Deploy to GitHub Pages


### PR DESCRIPTION
This reverts commit f2fe9ee0e10a505dc3eb8d27cf5f0e48df1b0c98.

The environment name is correct.