### PR TITLE
[build] Update `mkdocs-document-dates` to support properdocs

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,10 +1,10 @@
 properdocs==1.6.7
 mdx-truly-sane-lists==1.3
 markdown-include==0.8.1
-mkdocs-document-dates==3.8.0
+mkdocs-document-dates==3.8.2
 mkdocs-glightbox==0.5.2
-mkdocs-materialx==10.1.4
+mkdocs-materialx==10.1.5
 mkdocs-minify-plugin==0.8.0
-mkdocs-include-markdown-plugin==7.2.2
+mkdocs-include-markdown-plugin==7.3.0
 mkdocs-site-urls==0.3.1
 mkdocs-rss-plugin==1.19.0


### PR DESCRIPTION
Apply all available updates.

- mkdocs-document-dates: Added compatibility with `properdocs` See: https://github.com/jaywhj/mkdocs-document-dates/releases/tag/v3.8.2
- mkdocs-materialx: Code blocks can include a download button that supports blobs, URLs, and local file downloads. See: https://jaywhj.github.io/mkdocs-materialx/reference/code-blocks#enable-button